### PR TITLE
Update autoupdate_solana.sh

### DIFF
--- a/solana/autoupdate_solana.sh
+++ b/solana/autoupdate_solana.sh
@@ -26,7 +26,7 @@ for version in "${versions[@]}";do
       wget "https://release.solana.com/v${version}/install" -O ~/install
       chmod +x ~/install
       ./install
-      solana-validator --ledger {{ ansible_facts['env']['HOME'] }}/validator-ledger wait-for-restart-window --max-delinquent-stake 8
+      solana-validator --ledger {{ ansible_facts['env']['HOME'] }}/validator-ledger exit --max-delinquent-stake 8
       sudo systemctl restart solana
     fi
     break


### PR DESCRIPTION
solana-validator exit: Wait for first incremental snapshot after a full snapshot before restarting (backport #27471) (#27478) Solana restart should be faster as incremental snapshot needs less time to be created.